### PR TITLE
feat: enable skipping SCC provisioning

### DIFF
--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 offerings:
-  - name: Retrieval_Augmented_Generation_Pattern
+  - name: Retrieval_Augmented_Generation_Pattern_dev
     kind: solution
     catalog_id: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd
     offering_id: 5fdd0045-30fc-4013-a8bc-6db9d5447a52

--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -4,7 +4,7 @@ offerings:
   - name: Retrieval_Augmented_Generation_Pattern_dev
     kind: solution
     catalog_id: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd
-    offering_id: 5fdd0045-30fc-4013-a8bc-6db9d5447a52
+    offering_id: 6068c87c-ed4b-4427-be22-d7ac65fa2a8e
     variations:
       - name: Code-Engine-d7b9
         mark_ready: true

--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -7,7 +7,7 @@ offerings:
     offering_id: 5fdd0045-30fc-4013-a8bc-6db9d5447a52
     variations:
       - name: Code-Engine-d7b9
-        mark_ready: false
+        mark_ready: true
         install_type: fullstack
         format_kind: stack
         validation_type: projects

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,14 +15,14 @@ repository:
   # By changing this field, you rename the repository.
 
   # Uncomment this name property and set the name to the current repo name.
-  name: "stack-retrieval-augmented-generation"
+  name: "dev-rag"
 
   # The description is displayed under the repository name on the
   # organization page and in the 'About' section of the repository.
 
   # Uncomment this description property
   # and update the description to the current repo description.
-  # description: ""
+  description: "A temporary repo for development of rag stack"
 
   # Use a comma-separated list of topics to set on the repo (ensure not to use any caps in the topic string).
   topics: terraform, ibm-cloud, terraform-stack, ibm-cloud-stack, core-team

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -240,6 +240,12 @@
 							"default_value": "rag-services",
 							"description": "The name of the resource group that is created by this solution. The actual name is prefixed with the value of the input 'prefix'.  All resources created by this solution are deployed in this resource group. ",
 							"required": false
+						},						{
+							"key": "existing_resource_group_name",
+							"type": "string",
+							"default_value": "__NULL__",
+							"description": "The name of an existing resource group that is used by this solution. Prefix is NOT used for existing resource group.  All resources created by this solution are deployed in this resource group. ",
+							"required": false
 						},
 						{
 							"key": "watsonx_admin_api_key",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -138,6 +138,12 @@
 								"crn:v1:bluemix:public:iam::::role:Editor"
 							],
 							"service_name": "discovery"
+						},
+						{
+							"service_name": "databases-for-elasticsearch",
+							"role_crns": [
+							  "crn:v1:bluemix:public:iam::::role:Editor"
+							]
 						}
 					],
 					"architecture": {
@@ -288,6 +294,22 @@
 						}
 					],
 					"outputs": [
+						{
+							"key": "elasticsearch_hostname",
+							"description": "Elasticsearch instance hostname."
+						},
+						{
+							"key": "elasticsearch_port",
+							"description": "Elasticsearch instance port."
+						},
+						{
+							"key": "elasticsearch_service_credentials_json",
+							"description": "Elasticsearch instance service credentials json map."
+						},
+						{
+							"key": "elasticsearch_crn",
+							"description": "Elasticsearch instance crn."
+						},
 						{
 							"key": "watsonx_project_url",
 							"description": "The URL to the WatsonX project for the sample RAG application."

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -248,6 +248,13 @@
 							"required": false
 						},
 						{
+							"key": "existing_scc_instance_crn",
+							"type": "string",
+							"default_value": "__NULL__",
+							"description": "The CRN of an existing Security and Compliance Center instance. If not supplied, a new instance will be created.",
+							"required": false
+						},
+						{
 							"key": "watsonx_admin_api_key",
 							"type": "password",
 							"description": "The API key used to provision the watson project resources. If not set, the API key used to deploy the solution is used.",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -1,8 +1,8 @@
 {
 	"products": [
 		{
-			"label": "Retrieval Augmented Generation Pattern",
-			"name": "Retrieval_Augmented_Generation_Pattern",
+			"label": "Retrieval Augmented Generation Pattern (Dev)",
+			"name": "Retrieval_Augmented_Generation_Pattern_dev",
 			"product_kind": "solution",
 			"tags": [
 				"watson",

--- a/sample_deploy_config.json
+++ b/sample_deploy_config.json
@@ -9,8 +9,9 @@
     "2c - Security Service - Security Compliance Center",
     "3 - Observability - Logging Monitoring Activity Tracker",
     "4 - WatsonX SaaS services",
-    "5 - Sample RAG app - Application Lifecycle Management",
-    "6 - Sample RAG app configuration"
+    "5 - Databases for Elasticsearch",
+    "6 - Sample RAG app - Application Lifecycle Management",
+    "7 - Sample RAG app configuration"
   ],
   "stack_inputs": {
     "prefix": "<YOUR PREFIX HERE>",

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -72,7 +72,7 @@
   "members": [
     {
       "name": "1 - Account Infrastructure Base",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.be107739-fdfc-4089-95e0-def4abac847d-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.62aeb17c-2272-416c-b982-5f17fa508d04-global",
       "inputs": [
         {
           "name": "prefix",
@@ -262,7 +262,7 @@
     },
     {
       "name": "4 - WatsonX SaaS services",
-      "version_locator": "1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc.c237751c-d3dd-4c23-b0b1-ba726d30c8e9-global",
+      "version_locator": "1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc.a68377c5-2a73-4832-8fd9-ad5b73b5256b-global",
       "inputs": [
         {
           "name": "ibmcloud_api_key",
@@ -315,7 +315,57 @@
       ]
     },
     {
-      "name": "5 - Sample RAG app - Application Lifecycle Management",
+      "name": "5 - Databases for Elasticsearch",
+			"version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c5ea982b-011a-46c8-a49d-0de273f40b46-global",
+			"inputs": [
+				{
+					"name": "use_existing_resource_group",
+					"value": true
+				},
+				{
+					"name": "resource_group_name",
+					"value": "ref:../../members/1 - Account Infrastructure Base/outputs/workload_resource_group_name"
+				},
+				{
+					"name": "region",
+					"value": "ref:../../inputs/region"
+				},
+				{
+					"name": "prefix",
+					"value": "ref:../../inputs/prefix"
+				},
+				{
+					"name": "plan",
+					"value": "enterprise"
+				},
+				{
+					"name": "elasticsearch_version",
+					"value": "8.12"
+				},
+				{
+					"name": "existing_kms_instance_crn",
+					"value": "ref:../../members/2a - Security Service - Key Management/outputs/kms_instance_crn"
+				},
+				{
+					"name": "kms_endpoint_type",
+					"value": "private"
+				},
+				{
+					"name": "member_host_flavor",
+					"value": "b3c.4x16.encrypted"
+				},
+        {
+					"name": "service_credential_names",
+					"value": {
+						"elastic_db_admin" : "Administrator",
+						"wxasst_db_user" : "Editor",
+						"toolchain_db_user" : "Editor"
+					}
+				}
+			]
+		},
+    {
+      "name": "6 - Sample RAG app - Application Lifecycle Management",
       "version_locator": "1082e7d2-5e2f-0a11-a3bc-f88a8e1931fc.cce4d1b1-c09a-4c23-8aba-92f6e9f38cda-global",
       "inputs": [
         {
@@ -417,8 +467,8 @@
       ]
     },
     {
-      "name": "6 - Sample RAG app configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.af19228a-3182-46da-b52a-b1d9f662609d-global",
+      "name": "7 - Sample RAG app configuration",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.92fcdabc-7c4e-450e-9f1b-e6b059119aa7-global",
       "inputs": [
         {
           "name": "toolchain_region",
@@ -446,11 +496,11 @@
         },
         {
           "name": "cd_pipeline_id",
-          "value": "ref:../5 - Sample RAG app - Application Lifecycle Management/outputs/cd_pipeline_id"
+          "value": "ref:../6 - Sample RAG app - Application Lifecycle Management/outputs/cd_pipeline_id"
         },
         {
           "name": "ci_pipeline_id",
-          "value": "ref:../5 - Sample RAG app - Application Lifecycle Management/outputs/ci_pipeline_id"
+          "value": "ref:../6 - Sample RAG app - Application Lifecycle Management/outputs/ci_pipeline_id"
         },
         {
           "name": "watson_machine_learning_instance_guid",
@@ -500,6 +550,22 @@
     }
   ],
   "outputs": [
+		{
+		  "name": "elasticsearch_hostname",
+		  "value": "ref:./members/5 - Databases for Elasticsearch/outputs/hostname"
+		},
+		{
+		  "name": "elasticsearch_port",
+		  "value": "ref:./members/5 - Databases for Elasticsearch/outputs/port"
+		},
+		{
+		  "name": "elasticsearch_service_credentials_json",
+		  "value": "ref:./members/5 - Databases for Elasticsearch/outputs/service_credentials_json"
+		},
+    {
+		  "name": "elasticsearch_crn",
+		  "value": "ref:./members/5 - Databases for Elasticsearch/outputs/crn"
+		},
     {
       "name": "watsonx_project_url",
       "value": "ref:./members/6 - Sample RAG app configuration/outputs/watsonx_project_url"

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -69,6 +69,13 @@
       "default": null
     },
     {
+      "name": "existing_scc_instance_crn",
+      "required": false,
+      "type": "string",
+      "hidden": false,
+      "default": null
+    },
+    {
       "name": "enable_platform_logs_metrics",
       "required": false,
       "type": "boolean",
@@ -225,7 +232,7 @@
     },
     {
       "name": "2c - Security Service - Security Compliance Center",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f91391b9-72c3-48c2-b40d-fb27cfc7d00c-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.1ac9df0e-d3d5-4ed8-abfc-043578670dbb-global",
       "inputs": [
         {
           "name": "ibmcloud_api_key",
@@ -240,6 +247,14 @@
           "value": "ref:../../inputs/region"
         },
         {
+          "name": "existing_scc_instance_crn",
+          "value": "ref:../../inputs/existing_scc_instance_crn"
+        },
+        {
+          "name": "provision_scc_workload_protection",
+          "value": false
+        },
+        {
           "name": "resource_group_name",
           "value": "ref:../1 - Account Infrastructure Base/outputs/audit_resource_group_name"
         },
@@ -250,10 +265,6 @@
         {
           "name": "use_existing_resource_group",
           "value": true
-        },
-        {
-          "name": "provision_scc_workload_protection",
-          "value": false
         }
       ]
     },

--- a/stack_definition.json
+++ b/stack_definition.json
@@ -27,6 +27,13 @@
       "hidden": false
     },
     {
+      "name": "existing_resource_group_name",
+      "required": false,
+      "type": "string",
+      "hidden": false,
+      "default": null
+    },
+    {
       "name": "region",
       "required": false,
       "type": "string",
@@ -113,6 +120,34 @@
         {
           "name": "devops_resource_group_name",
           "value": "ref:../../inputs/resource_group_name"
+        },
+        {
+          "name": "existing_security_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_audit_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_observability_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_management_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_workload_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_edge_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
+        },
+        {
+          "name": "existing_devops_resource_group_name",
+          "value": "ref:../../inputs/existing_resource_group_name"
         },
         {
           "name": "provision_trusted_profile_projects",

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-ibm-modules/stack-retrieval-augmented-generation
+module github.com/terraform-ibm-modules/dev-rag
 
 go 1.21
 


### PR DESCRIPTION
### Description

Enable skipping SCC provisioning
https://github.com/terraform-ibm-modules/stack-retrieval-augmented-generation/issues/131

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

enable skipping SCC provisioning by providing option for passing existing scc instance id.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
