### PR TITLE
fix(deps): Update stack definition member versions

### DIFF
--- a/solutions/basic-without-sample-app/stack_definition.json
+++ b/solutions/basic-without-sample-app/stack_definition.json
@@ -168,7 +168,7 @@
   "members": [
     {
       "name": "1 - Account Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.3c6184a8-6772-41a4-a3f9-b12e93088caa-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.99200ca8-c18a-48b4-8a69-a2c33087d928-global",
       "inputs": [
         {
           "name": "prefix",
@@ -210,7 +210,7 @@
     },
     {
       "name": "2a - Essential Security - Encryption Key Management",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.fba8aa38-b3d8-4c5e-af43-e125f02e5f15-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.210731e1-812e-4253-a5c3-ab485285aed4-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -236,7 +236,7 @@
     },
     {
       "name": "2b - Essential Security - Cloud Object Storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a188a45a-0cc1-4f5b-86e5-d126b6097eb2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.dabe69f5-8e39-4c44-b692-9fc458bb02ea-global",
       "inputs": [
         {
           "name": "prefix",
@@ -250,7 +250,7 @@
     },
     {
       "name": "2c - Essential Security - Cloud Monitoring",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.50ebf77c-a703-404a-b803-1e5f11612bc0-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c925f8db-486d-47dd-a2f5-75a822c32c42-global",
       "inputs": [
         {
           "name": "region",
@@ -280,7 +280,7 @@
     },
     {
       "name": "2d - Workload - Code Engine Project",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.5e3d032e-608a-47c4-ae74-13a463a6453e-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c4c999ce-6aff-488e-80a3-e404c8ea92e3-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -302,7 +302,7 @@
     },
     {
       "name": "2e - Workload - Container Registry",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.215812bd-147c-47e1-ab1f-4f5add907936-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e7b4a5c1-1777-4325-8319-6eb7b1e4c042-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -324,7 +324,7 @@
     },
     {
       "name": "3a - Essential Security - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c087bb90-4cba-4569-8a5a-8cdf70cd0f24-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.8accba96-48f2-4641-b8e1-65adc766c8d4-global",
       "inputs": [
         {
           "name": "existing_cos_instance_crn",
@@ -448,7 +448,7 @@
     },
     {
       "name": "4a - Essential Security - Cloud Logs for logging",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -494,7 +494,7 @@
     },
     {
       "name": "4b - Essential Security - App Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.0da1eb31-bbea-483d-a600-2ea105ed5018-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.2c072ac6-0941-4c32-a38b-d910c0eff20b-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -560,7 +560,7 @@
     },
     {
       "name": "4c - Essential Security - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.86f1075b-de70-46bd-a6cd-aadfdda7e1da-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.77243305-ade8-40d7-9446-6a948b232e75-global",
       "inputs": [
         {
           "name": "prefix",
@@ -606,7 +606,7 @@
     },
     {
       "name": "4d - Essential Security - Cloud Logs for activity tracking",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -664,7 +664,7 @@
     },
     {
       "name": "5a - Essential Security - Security and Compliance Center Workload Protection",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.41d84a24-fc56-4094-9f73-265ddc7ab63b-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.05e542b1-f45e-4e01-a4cb-a829d60616f9-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -698,7 +698,7 @@
     },
     {
       "name": "5b - Gen AI - Databases for Elasticsearch",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e3e7ae87-0224-4893-9069-4b6dede0ca76-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.aab55ce1-e5a1-46cf-9805-ef8e454449e6-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -763,7 +763,7 @@
     },
     {
       "name": "5c - Essential Security - Activity Tracker Event Routing",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.247af203-d8ce-43bd-b8dc-f5375d94987d-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f4039829-46af-4641-99b7-3841d48060f1-global",
       "inputs": [
         {
           "name": "region",

--- a/solutions/basic/stack_definition.json
+++ b/solutions/basic/stack_definition.json
@@ -180,7 +180,7 @@
   "members": [
     {
       "name": "1 - Account Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.3c6184a8-6772-41a4-a3f9-b12e93088caa-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.99200ca8-c18a-48b4-8a69-a2c33087d928-global",
       "inputs": [
         {
           "name": "prefix",
@@ -226,7 +226,7 @@
     },
     {
       "name": "2a - Essential Security - Encryption Key Management",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.fba8aa38-b3d8-4c5e-af43-e125f02e5f15-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.210731e1-812e-4253-a5c3-ab485285aed4-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -252,7 +252,7 @@
     },
     {
       "name": "2b - Essential Security - Cloud Object Storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a188a45a-0cc1-4f5b-86e5-d126b6097eb2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.dabe69f5-8e39-4c44-b692-9fc458bb02ea-global",
       "inputs": [
         {
           "name": "prefix",
@@ -266,7 +266,7 @@
     },
     {
       "name": "2c - Essential Security - Cloud Monitoring",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.50ebf77c-a703-404a-b803-1e5f11612bc0-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c925f8db-486d-47dd-a2f5-75a822c32c42-global",
       "inputs": [
         {
           "name": "region",
@@ -296,7 +296,7 @@
     },
     {
       "name": "2d - Workload - Code Engine Project for CI",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.5e3d032e-608a-47c4-ae74-13a463a6453e-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c4c999ce-6aff-488e-80a3-e404c8ea92e3-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -318,7 +318,7 @@
     },
     {
       "name": "2e - Workload - Code Engine Project for CD",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.5e3d032e-608a-47c4-ae74-13a463a6453e-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c4c999ce-6aff-488e-80a3-e404c8ea92e3-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -340,7 +340,7 @@
     },
     {
       "name": "2f - Workload - Container Registry",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.215812bd-147c-47e1-ab1f-4f5add907936-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e7b4a5c1-1777-4325-8319-6eb7b1e4c042-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -362,7 +362,7 @@
     },
     {
       "name": "3a - Essential Security - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c087bb90-4cba-4569-8a5a-8cdf70cd0f24-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.8accba96-48f2-4641-b8e1-65adc766c8d4-global",
       "inputs": [
         {
           "name": "existing_cos_instance_crn",
@@ -486,7 +486,7 @@
     },
     {
       "name": "3c - Workload - DevSecOps evidence locker Object Storage bucket",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a5452fe9-844b-4155-b0f2-95fa76f1c548-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.59ca5bff-84c4-4f99-bcef-028d0331416f-global",
       "inputs": [
         {
           "name": "prefix",
@@ -528,7 +528,7 @@
     },
     {
       "name": "4a - Essential Security - Cloud Logs for logging",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -574,7 +574,7 @@
     },
     {
       "name": "4b - Essential Security - App Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.0da1eb31-bbea-483d-a600-2ea105ed5018-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.2c072ac6-0941-4c32-a38b-d910c0eff20b-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -640,7 +640,7 @@
     },
     {
       "name": "4c - Essential Security - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.86f1075b-de70-46bd-a6cd-aadfdda7e1da-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.77243305-ade8-40d7-9446-6a948b232e75-global",
       "inputs": [
         {
           "name": "prefix",
@@ -686,7 +686,7 @@
     },
     {
       "name": "4d - Essential Security - Cloud Logs for activity tracking",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -744,7 +744,7 @@
     },
     {
       "name": "5a - Essential Security - Security and Compliance Center Workload Protection",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.41d84a24-fc56-4094-9f73-265ddc7ab63b-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.05e542b1-f45e-4e01-a4cb-a829d60616f9-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -778,7 +778,7 @@
     },
     {
       "name": "5b - Gen AI - Databases for Elasticsearch",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e3e7ae87-0224-4893-9069-4b6dede0ca76-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.aab55ce1-e5a1-46cf-9805-ef8e454449e6-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -958,7 +958,7 @@
     },
     {
       "name": "5d - Essential Security - Activity Tracker Event Routing",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.247af203-d8ce-43bd-b8dc-f5375d94987d-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f4039829-46af-4641-99b7-3841d48060f1-global",
       "inputs": [
         {
           "name": "region",
@@ -996,7 +996,7 @@
     },
     {
       "name": "6 - Workload - Sample RAG Application",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a0281f82-6f2e-43b1-8dfe-593282fff40b-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.8fa6e24d-b5b3-449e-b3bc-9330c7a89eeb-global",
       "inputs": [
         {
           "name": "toolchain_region",

--- a/solutions/standard-without-sample-app/stack_definition.json
+++ b/solutions/standard-without-sample-app/stack_definition.json
@@ -168,7 +168,7 @@
   "members": [
     {
       "name": "1 - Account Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.3c6184a8-6772-41a4-a3f9-b12e93088caa-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.99200ca8-c18a-48b4-8a69-a2c33087d928-global",
       "inputs": [
         {
           "name": "prefix",
@@ -210,7 +210,7 @@
     },
     {
       "name": "2a - Essential Security - Encryption Key Management",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.fba8aa38-b3d8-4c5e-af43-e125f02e5f15-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.210731e1-812e-4253-a5c3-ab485285aed4-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -236,7 +236,7 @@
     },
     {
       "name": "2b - Essential Security - Cloud Object Storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a188a45a-0cc1-4f5b-86e5-d126b6097eb2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.dabe69f5-8e39-4c44-b692-9fc458bb02ea-global",
       "inputs": [
         {
           "name": "prefix",
@@ -250,7 +250,7 @@
     },
     {
       "name": "2c - Essential Security - Cloud Monitoring",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.50ebf77c-a703-404a-b803-1e5f11612bc0-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c925f8db-486d-47dd-a2f5-75a822c32c42-global",
       "inputs": [
         {
           "name": "region",
@@ -280,7 +280,7 @@
     },
     {
       "name": "2d - Workload - Container Registry",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.215812bd-147c-47e1-ab1f-4f5add907936-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e7b4a5c1-1777-4325-8319-6eb7b1e4c042-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -302,7 +302,7 @@
     },
     {
       "name": "3a - Essential Security - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c087bb90-4cba-4569-8a5a-8cdf70cd0f24-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.8accba96-48f2-4641-b8e1-65adc766c8d4-global",
       "inputs": [
         {
           "name": "existing_cos_instance_crn",
@@ -497,7 +497,7 @@
     },
     {
       "name": "4a - Essential Security - Cloud Logs for logging",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -543,7 +543,7 @@
     },
     {
       "name": "4b - Essential Security - App Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.0da1eb31-bbea-483d-a600-2ea105ed5018-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.2c072ac6-0941-4c32-a38b-d910c0eff20b-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -609,7 +609,7 @@
     },
     {
       "name": "4c - Essential Security - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.86f1075b-de70-46bd-a6cd-aadfdda7e1da-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.77243305-ade8-40d7-9446-6a948b232e75-global",
       "inputs": [
         {
           "name": "prefix",
@@ -655,7 +655,7 @@
     },
     {
       "name": "4d - Essential Security - Cloud Logs for activity tracking",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -713,7 +713,7 @@
     },
     {
       "name": "5a - Essential Security - Security and Compliance Center Workload Protection",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.41d84a24-fc56-4094-9f73-265ddc7ab63b-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.05e542b1-f45e-4e01-a4cb-a829d60616f9-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -747,7 +747,7 @@
     },
     {
       "name": "5b - Gen AI - Databases for Elasticsearch",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e3e7ae87-0224-4893-9069-4b6dede0ca76-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.aab55ce1-e5a1-46cf-9805-ef8e454449e6-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -821,7 +821,7 @@
     },
     {
       "name": "5c - Essential Security - Activity Tracker Event Routing",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.247af203-d8ce-43bd-b8dc-f5375d94987d-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f4039829-46af-4641-99b7-3841d48060f1-global",
       "inputs": [
         {
           "name": "region",
@@ -859,7 +859,7 @@
     },
     {
       "name": "5d - Workload Essential Security - Red Hat OpenShift logging agent",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.521809ce-aa93-432c-adf2-0110b195709c-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.5c20b307-1665-415f-bc89-456aca771fab-global",
       "inputs": [
         {
           "name": "prefix",
@@ -881,7 +881,7 @@
     },
     {
       "name": "5e - Workload Essential Security - Red Hat OpenShift Monitoring and Workload Protection agent",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.348c8e39-41dd-429f-8ffd-ff391c952fed-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.ea7189fb-8bb3-4b0d-9038-ad3a2ca12eb8-global",
       "inputs": [
         {
           "name": "prefix",

--- a/solutions/standard/stack_definition.json
+++ b/solutions/standard/stack_definition.json
@@ -180,7 +180,7 @@
   "members": [
     {
       "name": "1 - Account Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.3c6184a8-6772-41a4-a3f9-b12e93088caa-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.99200ca8-c18a-48b4-8a69-a2c33087d928-global",
       "inputs": [
         {
           "name": "prefix",
@@ -226,7 +226,7 @@
     },
     {
       "name": "2a - Essential Security - Encryption Key Management",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.fba8aa38-b3d8-4c5e-af43-e125f02e5f15-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.210731e1-812e-4253-a5c3-ab485285aed4-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -252,7 +252,7 @@
     },
     {
       "name": "2b - Essential Security - Cloud Object Storage",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a188a45a-0cc1-4f5b-86e5-d126b6097eb2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.dabe69f5-8e39-4c44-b692-9fc458bb02ea-global",
       "inputs": [
         {
           "name": "prefix",
@@ -266,7 +266,7 @@
     },
     {
       "name": "2c - Essential Security - Cloud Monitoring",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.50ebf77c-a703-404a-b803-1e5f11612bc0-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c925f8db-486d-47dd-a2f5-75a822c32c42-global",
       "inputs": [
         {
           "name": "region",
@@ -296,7 +296,7 @@
     },
     {
       "name": "2d - Workload - Container Registry",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.215812bd-147c-47e1-ab1f-4f5add907936-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e7b4a5c1-1777-4325-8319-6eb7b1e4c042-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -318,7 +318,7 @@
     },
     {
       "name": "3a - Essential Security - Event Notifications",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.c087bb90-4cba-4569-8a5a-8cdf70cd0f24-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.8accba96-48f2-4641-b8e1-65adc766c8d4-global",
       "inputs": [
         {
           "name": "existing_cos_instance_crn",
@@ -513,7 +513,7 @@
     },
     {
       "name": "3d - Workload - DevSecOps evidence locker Object Storage bucket",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a5452fe9-844b-4155-b0f2-95fa76f1c548-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.59ca5bff-84c4-4f99-bcef-028d0331416f-global",
       "inputs": [
         {
           "name": "prefix",
@@ -555,7 +555,7 @@
     },
     {
       "name": "4a - Essential Security - Cloud Logs for logging",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -601,7 +601,7 @@
     },
     {
       "name": "4b - Essential Security - App Configuration",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.0da1eb31-bbea-483d-a600-2ea105ed5018-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.2c072ac6-0941-4c32-a38b-d910c0eff20b-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -667,7 +667,7 @@
     },
     {
       "name": "4c - Essential Security - Secrets Manager",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.86f1075b-de70-46bd-a6cd-aadfdda7e1da-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.77243305-ade8-40d7-9446-6a948b232e75-global",
       "inputs": [
         {
           "name": "prefix",
@@ -713,7 +713,7 @@
     },
     {
       "name": "4d - Essential Security - Cloud Logs for activity tracking",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.d9c20c4d-dc28-44ff-bc71-5ce113e784a2-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.7c35fae5-48ef-470b-927a-8c5978b3f8b4-global",
       "inputs": [
         {
           "name": "region",
@@ -771,7 +771,7 @@
     },
     {
       "name": "5a - Essential Security - Security and Compliance Center Workload Protection",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.41d84a24-fc56-4094-9f73-265ddc7ab63b-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.05e542b1-f45e-4e01-a4cb-a829d60616f9-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -805,7 +805,7 @@
     },
     {
       "name": "5b - Gen AI - Databases for Elasticsearch",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.e3e7ae87-0224-4893-9069-4b6dede0ca76-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.aab55ce1-e5a1-46cf-9805-ef8e454449e6-global",
       "inputs": [
         {
           "name": "existing_resource_group_name",
@@ -985,7 +985,7 @@
     },
     {
       "name": "5d - Essential Security - Activity Tracker Event Routing",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.247af203-d8ce-43bd-b8dc-f5375d94987d-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.f4039829-46af-4641-99b7-3841d48060f1-global",
       "inputs": [
         {
           "name": "region",
@@ -1023,7 +1023,7 @@
     },
     {
       "name": "5e - Workload Essential Security - Red Hat OpenShift logging agent",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.521809ce-aa93-432c-adf2-0110b195709c-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.5c20b307-1665-415f-bc89-456aca771fab-global",
       "inputs": [
         {
           "name": "prefix",
@@ -1045,7 +1045,7 @@
     },
     {
       "name": "5f - Workload Essential Security - Red Hat OpenShift Monitoring and Workload Protection agent",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.348c8e39-41dd-429f-8ffd-ff391c952fed-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.ea7189fb-8bb3-4b0d-9038-ad3a2ca12eb8-global",
       "inputs": [
         {
           "name": "prefix",
@@ -1071,7 +1071,7 @@
     },
     {
       "name": "6 - Workload - Sample RAG Application",
-      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.a0281f82-6f2e-43b1-8dfe-593282fff40b-global",
+      "version_locator": "7a4d68b4-cf8b-40cd-a3d1-f49aff526eb3.8fa6e24d-b5b3-449e-b3bc-9330c7a89eeb-global",
       "inputs": [
         {
           "name": "toolchain_region",


### PR DESCRIPTION
Update stack definition member versions

| Stack | Change |
|---|---|
| 1 - Account Configuration | `v3.3.12` --> `v3.3.22` |
| 2a - Essential Security - Encryption Key Management | `v5.5.29` --> `v5.5.36` |
| 2b - Essential Security - Cloud Object Storage | `v10.14.1` --> `v10.14.10` |
| 2c - Essential Security - Cloud Monitoring | `v1.13.5` --> `v1.14.5` |
| 2d - Workload - Code Engine Project | `v1.1.28` --> `v1.2.5` |
| 2e - Workload - Container Registry | `v2.6.13` --> `v2.6.14` |
| 3a - Essential Security - Event Notifications | `v2.11.16` --> `v2.11.29` |
| 4a - Essential Security - Cloud Logs for logging | `v1.11.4` --> `v1.12.8` |
| 4b - Essential Security - App Configuration | `v1.15.7` --> `v1.16.1` |
| 4c - Essential Security - Secrets Manager | `v2.13.3` --> `v2.13.9` |
| 4d - Essential Security - Cloud Logs for activity tracking | `v1.11.4` --> `v1.12.8` |
| 5a - Essential Security - Security and Compliance Center Workload Protection | `v1.17.4` --> `v1.18.2` |
| 5b - Gen AI - Databases for Elasticsearch | `v2.11.0` --> `v2.12.0` |
| 5c - Essential Security - Activity Tracker Event Routing | `v1.6.13` --> `v1.7.1` |
| 2d - Workload - Code Engine Project for CI | `v1.1.28` --> `v1.2.5` |
| 2e - Workload - Code Engine Project for CD | `v1.1.28` --> `v1.2.5` |
| 2f - Workload - Container Registry | `v2.6.13` --> `v2.6.14` |
| 3c - Workload - DevSecOps evidence locker Object Storage bucket | `v10.14.1` --> `v10.14.10` |
| 5d - Essential Security - Activity Tracker Event Routing | `v1.6.13` --> `v1.7.1` |
| 6 - Workload - Sample RAG Application | `v2.8.6` --> `v2.10.1` |
| 2d - Workload - Container Registry | `v2.6.13` --> `v2.6.14` |
| 5d - Workload Essential Security - Red Hat OpenShift logging agent | `v1.18.1` --> `v1.20.2` |
| 5e - Workload Essential Security - Red Hat OpenShift Monitoring and Workload Protection agent | `v1.20.0` --> `v1.21.4` |
| 3d - Workload - DevSecOps evidence locker Object Storage bucket | `v10.14.1` --> `v10.14.10` |
| 5e - Workload Essential Security - Red Hat OpenShift logging agent | `v1.18.1` --> `v1.20.2` |
| 5f - Workload Essential Security - Red Hat OpenShift Monitoring and Workload Protection agent | `v1.20.0` --> `v1.21.4` |
